### PR TITLE
Fixed flaky test named `com.graphhopper.routing.DirectionResolverOnQueryGraphTest#duplicateCoordinatesAtBaseOrAdjNode`

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/DirectionResolver.java
+++ b/core/src/main/java/com/graphhopper/routing/DirectionResolver.java
@@ -223,7 +223,7 @@ public class DirectionResolver {
     private static class AdjacentEdges {
         private final Map<Point, List<Edge>> inEdgesByNextPoint = new HashMap<>(2);
         private final Map<Point, List<Edge>> outEdgesByNextPoint = new HashMap<>(2);
-        final Set<Point> nextPoints = new HashSet<>(2);
+        final Set<Point> nextPoints = new LinkedHashSet<>(2);
         int numLoops;
         int numStandardEdges;
         int numZeroDistanceEdges;


### PR DESCRIPTION
### What is the purpose of this PR
* This PR fixes the flaky test named `com.graphhopper.routing.DirectionResolverOnQueryGraphTest#duplicateCoordinatesAtBaseOrAdjNode`.
* This test may pass or fail without any changes being made to the source code depending on the different JVM version being used, due to `HashSet`'s non-deterministic behavior.

### Why the test fails
* The test is flaky because the underlying `AdjacentEdges` class contains a member variable called `nextPoints` which is of type `HashSet`, and in the `resolveDirections` function an `iterator` object is used on the `nextPoints` variable. Since the order of the elements of a `HashSet` is non-deterministic as indicated in the [Java documentation](https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html), this test depends on the implementation details and it may fail when it is run in different JVMs.

### How to reproduce the test failure
* Run the test using the `NonDex` Maven plugin:
* `mvn -pl core test edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.graphhopper.routing.DirectionResolverOnQueryGraphTest#duplicateCoordinatesAtBaseOrAdjNode`

### Expected results
* The test should be successful when run with the `NonDex` Maven plugin.

### Actual results
* `[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.099 s <<< FAILURE! - in com.graphhopper.routing.DirectionResolverOnQueryGraphTest
[ERROR] duplicateCoordinatesAtBaseOrAdjNode  Time elapsed: 0.094 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: unexpected resolved direction ==> expected: <in-edge-right: 1, out-edge-right: 2, in-edge-left: 2, out-edge-left: 1> but was: <in-edge-right: 2, out-edge-right: 1, in-edge-left: 1, out-edge-left: 2>`

### Description of fix
* Changed the type of the `nextPoints` member variable in `AdjacentEdges` class from `HashSet` to `LinkedHashSet` to ensure deterministic order of elements. 